### PR TITLE
Copy data sections before copying binaries

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -454,16 +454,16 @@ class Bundler:
         self.resolve_library_dependencies()
         self.binaries_to_copy.remove(main_binary_path)
 
+        # Data
+        for path in self.project.get_data():
+            path.copy_target(self.project)
+
         # Additional binaries (executables, libraries, modules)
         self.copy_binaries()
         self.resolve_library_dependencies()
 
         # Gir and Typelibs
         self.install_gir()
-
-        # Data
-        for path in self.project.get_data():
-            path.copy_target(self.project)
 
         # Translations
         self.copy_translations()


### PR DESCRIPTION
Copying binaries has secondary effects such as run-install-name-tool,
and if any of the specified binaries are overwritten by a data section,
those effects will be overwritten as well. An example from my project:

    <binary>${prefix}/lib/python2.7/lib-dynload/*.so</binary>
    <data>${prefix}/lib/python2.7</data>

In this case, we want to grab all the python modules, and make all the
dynamically loaded binary modules relocatable with
run-install-name-tool. But since data files are copied later than
binaries, the relocated binaries are overwritten.

There are other solutions: we could enumerate all the data files
individually or by glob instead of specifying the whole prefix. The
copy_target function could avoid overwriting existing files. But this
was the simplest option that worked for me.